### PR TITLE
Add curl and procps packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN buildDeps='curl ca-certificates build-essential zlib1g-dev python cmake'; \
   mv ./kafkacat /usr/local/bin/; \
   \
   rm -rf /usr/src/kafkacat/tmp-bootstrap; \
-  apt-get purge -y --auto-remove $buildDeps
+  apt-get purge -y --auto-remove $buildDeps; \
+  apt-get autoremove --purge -y
 
 ENTRYPOINT ["kafkacat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:stable-20170620
 
-RUN buildDeps='curl ca-certificates build-essential zlib1g-dev python cmake'; \
+RUN runDeps='curl ca-certificates procps'; \
+  buildDeps='build-essential zlib1g-dev python cmake'; \
   set -ex; \
-  apt-get update && apt-get install -y $buildDeps --no-install-recommends; \
+  apt-get update && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
   rm -rf /var/lib/apt/lists/*; \
   \
   mkdir /usr/src/kafkacat; \


### PR DESCRIPTION
This is for a specific use case, https://github.com/Yolean/kubernetes-kafka/pull/39

It does an additional cleanup step https://github.com/solsson/docker-kafkacat/commit/6dcd6a4f14ce5d7be001b047e36212b9885d1c35 that might be useful in https://github.com/ryane/docker-kafkacat/pull/4.
